### PR TITLE
Use paste instead of tagging tokens if it exists

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -681,8 +681,13 @@ uis.controller('uiSelectCtrl',
     data = ctrl.search + data;
 
     if (data && data.length > 0) {
-      // If tagging try to split by tokens and add items
-      if (ctrl.taggingTokens.isActivated) {
+      if (ctrl.paste) {
+        ctrl.paste(data);
+        ctrl.search = EMPTY_SEARCH;
+        e.preventDefault();
+        e.stopPropagation();
+      } else if (ctrl.taggingTokens.isActivated) {
+        // If tagging try to split by tokens and add items
         var items = [];
         for (var i = 0; i < ctrl.taggingTokens.tokens.length; i++) {  // split by first token that is contained in data
           var separator = KEY.toSeparator(ctrl.taggingTokens.tokens[i]) || ctrl.taggingTokens.tokens[i];
@@ -702,11 +707,6 @@ uis.controller('uiSelectCtrl',
           }
         });
         ctrl.search = oldsearch || EMPTY_SEARCH;
-        e.preventDefault();
-        e.stopPropagation();
-      } else if (ctrl.paste) {
-        ctrl.paste(data);
-        ctrl.search = EMPTY_SEARCH;
         e.preventDefault();
         e.stopPropagation();
       }

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -1814,6 +1814,7 @@ describe('ui-select tests', function() {
             if (attrs.tagging !== undefined) { attrsHtml += ' tagging="' + attrs.tagging + '"'; }
             if (attrs.taggingTokens !== undefined) { attrsHtml += ' tagging-tokens="' + attrs.taggingTokens + '"'; }
             if (attrs.taggingLabel !== undefined) { attrsHtml += ' tagging-label="' + attrs.taggingLabel + '"'; }
+            if (attrs.paste !== undefined) { attrsHtml += ' paste="' + attrs.paste + '"'; }
             if (attrs.inputId !== undefined) { attrsHtml += ' input-id="' + attrs.inputId + '"'; }
             if (attrs.groupBy !== undefined) { choicesAttrsHtml += ' group-by="' + attrs.groupBy + '"'; }
             if (attrs.lockChoice !== undefined) { matchesAttrsHtml += ' ui-lock-choice="' + attrs.lockChoice + '"'; }
@@ -2733,6 +2734,17 @@ describe('ui-select tests', function() {
       triggerPaste(el.find('input'), 'tag1');
 
       expect($(el).scope().$select.selected).toEqual(['tag1']);
+    });
+
+    it('should use paste function with tagging-tokens', function() {
+      scope.pasteFunc = function(string){};
+      spyOn(scope, 'pasteFunc');
+
+      var el = createUiSelectMultiple({tagging: true, paste: "pasteFunc", taggingTokens: ","});
+      clickMatch(el);
+      triggerPaste(el.find('input'), 'tag1');
+
+      expect(scope.pasteFunc).toHaveBeenCalledWith('tag1');
     });
 
     it('should add an id to the search input field', function () {


### PR DESCRIPTION
ui-select has a `paste` option, where you provide your own function for pasting values. But, if you have custom tagging tokens, it won't use the paste function! This just give preference to the paste function if you have it.

@arkarkark this is part of some modifications I'd like to make to ui-select for our filter suggestions. I'm hoping to merge them here for our use and then potentially open a PR against ui-select later if I think these changes would be useful to others. Let me know what you think!