### PR TITLE
Add tagging token escape and tag on blur options

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -26,6 +26,7 @@ uis.controller('uiSelectCtrl',
   ctrl.removeSelected = uiSelectConfig.removeSelected; //If selected item(s) should be removed from dropdown list
   ctrl.closeOnSelect = true; //Initialized inside uiSelect directive link function
   ctrl.skipFocusser = false; //Set to true to avoid returning focus to ctrl when item is selected
+  ctrl.tagOnBlur = false;
   ctrl.search = EMPTY_SEARCH;
 
   ctrl.activeIndex = 0; //Dropdown of choices
@@ -461,7 +462,9 @@ uis.controller('uiSelectCtrl',
     if (!ctrl.open) return;
     if (ctrl.ngModel && ctrl.ngModel.$setTouched) ctrl.ngModel.$setTouched();
     ctrl.open = false;
-    _resetSearchInput();
+    if (!ctrl.tagOnBlur) {
+      _resetSearchInput();
+    }
     $scope.$broadcast('uis:close', skipFocusser);
 
   };
@@ -727,6 +730,28 @@ uis.controller('uiSelectCtrl',
         e.preventDefault();
         e.stopPropagation();
       }
+    }
+  });
+
+  // Allow tagging on blur
+  ctrl.searchInput.on('blur', function() {
+    if (ctrl.tagging.isActivated && ctrl.tagOnBlur) {
+      $timeout(function() {
+        ctrl.searchInput.triggerHandler('tagged');
+        var newItem = ctrl.search;
+
+        // replace all tagging tokens
+        if (ctrl.taggingTokens.isActivated) {
+          for (var i = 0; i < ctrl.taggingTokens.tokens.length; i++) {
+            newItem = _replaceTaggingTokens(newItem, ctrl.taggingTokens.tokens[i]);
+          }
+        }
+
+        if ( ctrl.tagging.fct ) {
+          newItem = ctrl.tagging.fct( newItem );
+        }
+        if (newItem) ctrl.select(newItem, true);
+      });
     }
   });
 

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -149,6 +149,11 @@ uis.directive('uiSelect',
           }
         });
 
+        attrs.$observe('tagOnBlur', function() {
+          // $eval() is needed otherwise we get a string instead of a boolean
+          $select.tagOnBlur = scope.$eval(attrs.tagOnBlur) === true ? true : false;
+        });
+
         attrs.$observe('spinnerEnabled', function() {
           // $eval() is needed otherwise we get a string instead of a boolean
           var spinnerEnabled = scope.$eval(attrs.spinnerEnabled);

--- a/src/uiSelectDirective.js
+++ b/src/uiSelectDirective.js
@@ -143,6 +143,12 @@ uis.directive('uiSelect',
           }
         });
 
+        attrs.$observe('taggingTokenEscape', function() {
+          if (attrs.tagging !== undefined) {
+            $select.taggingTokenEscape = attrs.taggingTokenEscape;
+          }
+        });
+
         attrs.$observe('spinnerEnabled', function() {
           // $eval() is needed otherwise we get a string instead of a boolean
           var spinnerEnabled = scope.$eval(attrs.spinnerEnabled);

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -158,6 +158,7 @@ describe('ui-select tests', function() {
       if (attrs.tagging !== undefined) { attrsHtml += ' tagging="' + attrs.tagging + '"'; }
       if (attrs.taggingTokens !== undefined) { attrsHtml += ' tagging-tokens="' + attrs.taggingTokens + '"'; }
       if (attrs.taggingTokenEscape !== undefined) { attrsHtml += ' tagging-token-escape="' + attrs.taggingTokenEscape + '"'; }
+      if (attrs.tagOnBlur !== undefined) { attrsHtml += ' tag-on-blur="' + attrs.tagOnBlur + '"'; }
       if (attrs.title !== undefined) { attrsHtml += ' title="' + attrs.title + '"'; }
       if (attrs.appendToBody !== undefined) { attrsHtml += ' append-to-body="' + attrs.appendToBody + '"'; }
       if (attrs.allowClear !== undefined) { matchAttrsHtml += ' allow-clear="' + attrs.allowClear + '"';}
@@ -1817,6 +1818,7 @@ describe('ui-select tests', function() {
             if (attrs.taggingTokens !== undefined) { attrsHtml += ' tagging-tokens="' + attrs.taggingTokens + '"'; }
             if (attrs.taggingLabel !== undefined) { attrsHtml += ' tagging-label="' + attrs.taggingLabel + '"'; }
             if (attrs.taggingTokenEscape !== undefined) { attrsHtml += ' tagging-token-escape="' + attrs.taggingTokenEscape + '"'; }
+            if (attrs.tagOnBlur !== undefined) { attrsHtml += ' tag-on-blur="' + attrs.tagOnBlur + '"'; }
             if (attrs.inputId !== undefined) { attrsHtml += ' input-id="' + attrs.inputId + '"'; }
             if (attrs.groupBy !== undefined) { choicesAttrsHtml += ' group-by="' + attrs.groupBy + '"'; }
             if (attrs.lockChoice !== undefined) { matchesAttrsHtml += ' ui-lock-choice="' + attrs.lockChoice + '"'; }
@@ -2807,6 +2809,50 @@ describe('ui-select tests', function() {
       triggerKeydown(searchInput, Key.Comma);
       $timeout.flush();
       expect($(el).scope().$select.selected).toEqual(['tag,,tag']);
+    });
+  });
+
+  describe('tagOnBlur option', function () {
+    it('should be false by default', function() {
+      var el = createUiSelect();
+      expect(el.scope().$select.tagOnBlur).toEqual(false);
+    });
+
+    it('should be true when set', function() {
+      var el = createUiSelect({tagOnBlur: true});
+      expect(el.scope().$select.tagOnBlur).toEqual(true);
+    });
+
+    it('should tag on blur when true', function () {
+      var el = createUiSelect({tagging: true, tagOnBlur: true});
+      setSearchText(el, 'tag');
+      el.scope().$select.searchInput.trigger('blur');
+      $timeout.flush();
+      expect(el.scope().$select.selected).toEqual('tag');
+    });
+
+    it('should tag on blur when true with multiple', function () {
+      var el = createUiSelectMultiple({tagging: true, tagOnBlur: true});
+      setSearchText(el, 'tag');
+      el.scope().$select.searchInput.trigger('blur');
+      $timeout.flush();
+      expect(el.scope().$select.selected).toEqual(['tag']);
+    });
+
+    it('should convert escaped token to token', function () {
+      var el = createUiSelectMultiple({tagging: true, taggingTokenEscape: '^', taggingTokens: ',', tagOnBlur: true});
+      setSearchText(el, 'tag^,tag');
+      el.scope().$select.searchInput.trigger('blur');
+      $timeout.flush();
+      expect(el.scope().$select.selected).toEqual(['tag,tag']);
+    });
+
+    it('should not remove tagging token unless at the end', function () {
+      var el = createUiSelectMultiple({tagging: true, taggingTokenEscape: '^', taggingTokens: ',', tagOnBlur: true});
+      setSearchText(el, 'tag,tag,');
+      el.scope().$select.searchInput.trigger('blur');
+      $timeout.flush();
+      expect(el.scope().$select.selected).toEqual(['tag,tag']);
     });
   });
 

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -12,7 +12,8 @@ describe('ui-select tests', function() {
     Right: 39,
     Backspace: 8,
     Delete: 46,
-    Escape: 27
+    Escape: 27,
+    Comma: 188
   };
 
   //create a directive that wraps ui-select
@@ -156,6 +157,7 @@ describe('ui-select tests', function() {
       if (attrs.tabindex !== undefined) { attrsHtml += ' tabindex="' + attrs.tabindex + '"'; }
       if (attrs.tagging !== undefined) { attrsHtml += ' tagging="' + attrs.tagging + '"'; }
       if (attrs.taggingTokens !== undefined) { attrsHtml += ' tagging-tokens="' + attrs.taggingTokens + '"'; }
+      if (attrs.taggingTokenEscape !== undefined) { attrsHtml += ' tagging-token-escape="' + attrs.taggingTokenEscape + '"'; }
       if (attrs.title !== undefined) { attrsHtml += ' title="' + attrs.title + '"'; }
       if (attrs.appendToBody !== undefined) { attrsHtml += ' append-to-body="' + attrs.appendToBody + '"'; }
       if (attrs.allowClear !== undefined) { matchAttrsHtml += ' allow-clear="' + attrs.allowClear + '"';}
@@ -1814,6 +1816,7 @@ describe('ui-select tests', function() {
             if (attrs.tagging !== undefined) { attrsHtml += ' tagging="' + attrs.tagging + '"'; }
             if (attrs.taggingTokens !== undefined) { attrsHtml += ' tagging-tokens="' + attrs.taggingTokens + '"'; }
             if (attrs.taggingLabel !== undefined) { attrsHtml += ' tagging-label="' + attrs.taggingLabel + '"'; }
+            if (attrs.taggingTokenEscape !== undefined) { attrsHtml += ' tagging-token-escape="' + attrs.taggingTokenEscape + '"'; }
             if (attrs.inputId !== undefined) { attrsHtml += ' input-id="' + attrs.inputId + '"'; }
             if (attrs.groupBy !== undefined) { choicesAttrsHtml += ' group-by="' + attrs.groupBy + '"'; }
             if (attrs.lockChoice !== undefined) { matchesAttrsHtml += ' ui-lock-choice="' + attrs.lockChoice + '"'; }
@@ -2763,6 +2766,49 @@ describe('ui-select tests', function() {
          clickItem(el, 'Wladimir');
          expect(el.scope().$select.selected.length).toBe(2);
      });
+
+  describe('taggingTokenEscape option multiple', function() {
+    it('should have a set value', function () {
+      var el = createUiSelectMultiple({tagging: true, taggingTokenEscape: '^'});
+      expect(el.scope().$select.taggingTokenEscape).toEqual('^');
+    });
+
+    it('should tag normally if not set', function () {
+      var el = createUiSelectMultiple({tagging: true, taggingTokens: ','});
+      var searchInput = el.find('.ui-select-search');
+      setSearchText(el, 'tag');
+      triggerKeydown(searchInput, Key.Comma);
+      $timeout.flush();
+      expect($(el).scope().$select.selected).toEqual(['tag']);
+    });
+
+    it('should not tag after escape sequence', function () {
+      var el = createUiSelectMultiple({tagging: true, taggingTokenEscape: '^', taggingTokens: ','});
+      var searchInput = el.find('.ui-select-search');
+      setSearchText(el, 'tag^');
+      triggerKeydown(searchInput, Key.Comma);
+      expect(function() {$timeout.flush();}).toThrow(); // ensure there are no deferred tasks
+      expect($(el).scope().$select.selected).toEqual([]);
+    });
+
+    it('should convert escaped token to token when tagging happens', function () {
+      var el = createUiSelectMultiple({tagging: true, taggingTokenEscape: '^', taggingTokens: ','});
+      var searchInput = el.find('.ui-select-search');
+      setSearchText(el, 'tag^,');
+      triggerKeydown(searchInput, Key.Comma);
+      $timeout.flush();
+      expect($(el).scope().$select.selected).toEqual(['tag,']);
+    });
+
+    it('should not remove tagging token in the middle', function () {
+      var el = createUiSelectMultiple({tagging: true, taggingTokenEscape: '^', taggingTokens: ','});
+      var searchInput = el.find('.ui-select-search');
+      setSearchText(el, 'tag,^,tag');
+      triggerKeydown(searchInput, Key.Comma);
+      $timeout.flush();
+      expect($(el).scope().$select.selected).toEqual(['tag,,tag']);
+    });
+  });
 
   describe('resetSearchInput option multiple', function () {
       it('should be true by default', function () {


### PR DESCRIPTION
This adds two new options:

1. `tagging-token-escape`: an escape sequence for the tagging tokens. If you type the escape sequence before the tagging token, it will not try to tag. And when you do tag, it will remove the escape sequences from the final value.

2. `tag-on-blur`: boolean for whether you want to tag the value in the search input when it loses focus.

cc @arkarkark (same situation as https://github.com/looker/ui-select/pull/1)