### PR TITLE
A11y: Make Delete Button on Match Multiple Accessible to SR

### DIFF
--- a/src/bootstrap/match-multiple.tpl.html
+++ b/src/bootstrap/match-multiple.tpl.html
@@ -8,7 +8,7 @@
       ng-click="$selectMultiple.activeMatchIndex = $index; $select.focusSearchInput();"
       ng-class="{'btn-primary':$selectMultiple.isActiveChoice($index), 'select-locked':$select.isLocked(this, $index)}"
       ui-select-sort="$select.selected">
-        <span class="close ui-select-match-close" ng-hide="$select.disabled" ng-click="$selectMultiple.removeChoice($index)">&nbsp;&times;</span>
+        <span class="close ui-select-match-close" ng-hide="$select.disabled" ng-click="$selectMultiple.removeChoice($index)" aria-label="remove item">&nbsp;&times;</span>
         <span uis-transclude-append></span>
     </span>
   </span>


### PR DESCRIPTION
This is a naive, trial balloon PR to add an aria label to match multiple component, so that the "x" button on an item will be properly labeled for screen reader users. (This button removes the item from the list.)

I have a couple of big questions that come with this PR that I would like to answer and address:

1. I have not been able to build the library locally, so am not 100% sure that this update will even have the effect I expect. What is the right way to build this locally, as there seems to be a mismatch between gulp and our current version of NodeJS, but when I downgraded NodeJS, I ran into a lot of other issues (perhaps a mismatch with XCode?).

2. Assuming that this update does what I expect, it is not localized. As far as I can tell, localizability is not handled at all in this library. What is the best way to address localization within this library?

In theory this is a very simple fix, but I am hoping that folks with localization and library-specific expertise can shed some light on areas that are still opaque for me.

Resolves DX-5500